### PR TITLE
Update signature.rb

### DIFF
--- a/lib/net/http/signature.rb
+++ b/lib/net/http/signature.rb
@@ -16,7 +16,7 @@ module Net
       end
 
       def valid?(string)
-        to_s == string
+        to_s.strip == string.strip
       end
 
       def to_s


### PR DESCRIPTION
Bug where passing the header directly in will have a \n causing the header to incorrectly return `valid?` as false